### PR TITLE
document: allowed numeric types fix

### DIFF
--- a/cernservicexml/_compat.py
+++ b/cernservicexml/_compat.py
@@ -24,11 +24,13 @@ if PY3:  # pragma: no cover
     text_type = str
     binary_type = bytes
     from io import StringIO
+    long_type = int
 else:    # pragma: no cover
     string_types = basestring,
     text_type = unicode
     binary_type = str
     from StringIO import StringIO
+    long_type = long
 
 
 def import_httpretty():  # pragma: no cover

--- a/cernservicexml/document.py
+++ b/cernservicexml/document.py
@@ -23,7 +23,7 @@ import xml.etree.ElementTree as ET
 from datetime import datetime
 from decimal import Decimal
 
-from ._compat import string_types, text_type, binary_type
+from ._compat import string_types, text_type, binary_type, long_type
 
 
 class ServiceDocument(object):
@@ -70,7 +70,7 @@ class ServiceDocument(object):
         """
         assert isinstance(name, string_types)
         assert isinstance(value, int) or isinstance(value, float) or \
-            isinstance(value, Decimal)
+            isinstance(value, Decimal) or isinstance(value, long_type)
         if desc is not None:
             assert isinstance(desc, string_types)
         self.data.append(dict(name=name, desc=desc, value=value))

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -17,7 +17,7 @@ from os.path import dirname, join
 
 import pytest
 from cernservicexml import ServiceDocument
-from cernservicexml._compat import StringIO
+from cernservicexml._compat import StringIO, long_type
 from lxml import etree
 
 schema = etree.XMLSchema(file=join(dirname(__file__), 'xsls_schema.xsd'))
@@ -114,6 +114,7 @@ def test_numericvalue():
     doc.add_numericvalue('val3', Decimal("0.1"))
     doc.add_numericvalue('val4', Decimal("0.1") + Decimal("0.2"))
     doc.add_numericvalue('val5', 1234, desc="a desc")
+    doc.add_numericvalue('val6', long_type(1234))
 
     assert doc.to_xml() == \
         '<serviceupdate xmlns="http://sls.cern.ch/SLS/XML/update">' \
@@ -126,6 +127,7 @@ def test_numericvalue():
         '<numericvalue name="val3">0.1</numericvalue>' \
         '<numericvalue name="val4">0.3</numericvalue>' \
         '<numericvalue desc="a desc" name="val5">1234</numericvalue>' \
+        '<numericvalue name="val6">1234</numericvalue>' \
         '</data>' \
         '</serviceupdate>'
     assert validate_xsd(doc.to_xml())


### PR DESCRIPTION
* Adds support for long (Python 2) integers.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>