### PR TITLE
docker: initial release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+*.pyc
+__pycache__/
+.tox
+.cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "docs/_themes"]
-	path = docs/_themes
-	url = https://github.com/mitsuhiko/flask-sphinx-themes

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Authors
 Contact us at `info@invenio-software.org <mailto:info@invenio-software.org>`_
 
 * Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
+* Tibor Simko <tibor.simko@cern.ch>

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -21,4 +21,4 @@ operating correctly:
 You can also test your feature branch using Docker::
 
   $ docker-compose build
-  $ docker-compose run --rm web python setup.py test
+  $ docker-compose run --rm web /code/run-tests.sh

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -17,3 +17,8 @@ operating correctly:
 .. code-block:: console
 
     $ ./run-tests.sh
+
+You can also test your feature branch using Docker::
+
+  $ docker-compose build
+  $ docker-compose run --rm web python setup.py test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# This file is part of CERN Service XML
+# Copyright (C) 2015 CERN.
+#
+# CERN Service XML is free software; you can redistribute it and/or modify
+# it under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+# Use Python-2.7:
+FROM python:2.7
+
+# Install some prerequisites ahead of `setup.py` in order to profit
+# from the docker build cache:
+RUN pip install coveralls \
+                httpretty \
+                ipython \
+                lxml \
+                mock \
+                pep257 \
+                pytest \
+                pytest-cache \
+                pytest-cov \
+                pytest-pep8 \
+                requests \
+                six \
+                sphinx_rtd_theme
+
+# Add sources to `code` and work there:
+WORKDIR /code
+ADD . /code
+
+# Install cernservicexml:
+RUN pip install -e .
+
+# Run container as user `cernservicexml` with UID `1000`, which should match
+# current host user in most situations:
+RUN adduser --uid 1000 --disabled-password --gecos '' cernservicexml && \
+    chown -R cernservicexml:cernservicexml /code
+
+# Run test suite instead of starting the application:
+USER cernservicexml
+CMD ["python", "setup.py", "test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ WORKDIR /code
 ADD . /code
 
 # Install cernservicexml:
-RUN pip install -e .
+RUN pip install -e .[docs]
 
 # Run container as user `cernservicexml` with UID `1000`, which should match
 # current host user in most situations:

--- a/README.rst
+++ b/README.rst
@@ -27,8 +27,6 @@ Documentation
 Documentation is readable at http://cernservicexml.readthedocs.org or can be
 build using Sphinx: ::
 
-    git submodule init
-    git submodule update
     pip install Sphinx
     python setup.py build_sphinx
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+# This file is part of CERN Service XML
+# Copyright (C) 2015 CERN.
+#
+# CERN Service XML is free software; you can redistribute it and/or modify
+# it under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+web:
+  build: .
+  command: python setup.py test
+  volumes:
+   - .:/code

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,10 @@
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 
+"""Sphinx configuration."""
+
+from __future__ import print_function
+
 import sys
 import os
 import re
@@ -105,21 +109,23 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme_path = ['_themes']
-html_theme = 'flask_small'
-
+html_theme_path = []
+html_theme = 'sphinx_rtd_theme'
+try:
+    import sphinx_rtd_theme
+    _html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+except ImportError:
+    print("`sphinx_rtd_theme` not found, pip install it", file=sys.stderr)
+    _html_theme = "default"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {
-    'index_logo': False,
-    'index_logo_height': '40px;',
-    'github_fork': 'inveniosoftware/cernservicexml',
-}
+#html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
+html_theme_path = _html_theme_path
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
@@ -151,9 +157,7 @@ html_theme_options = {
 #html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-html_sidebars = {
-    'index': ['sidebarintro.html', 'sourcelink.html', 'searchbox.html'],
-}
+#html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,9 @@ setup(
     install_requires=[
         "requests>=2.3",
     ],
+    extras_require={
+        'docs': ['sphinx_rtd_theme'],
+    },
     cmdclass={'test': PyTest},
     classifiers=[
         'Programming Language :: Python :: 2',


### PR DESCRIPTION
- docs: use sphinx_rtd_theme
    
    * BETTER Changes documentation theme to the standard non-Flask RTD one.
    
    * One can now use `docker-compose run --rm web /code/run-tests.sh` to
      run all the CI tests (pep257, sphinx, test suite).

- docker: initial release
    
    * NEW Initial release of Docker configuration suitable for local
      developments.  `docker-compose build` rebuilds the image,
      `docker-compose run --rm web python setup.py test` runs the test
      suite.
    