### PR TITLE
document: service status support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Version 0.2 (released TBD)
+
+- Adds support for service status parameter in ``ServiceDocument``.
+- Deprecates use of service availability percentage in ``ServiceDocument``.
+  Please use service status parameter instead.
+
 Version 0.1.2 (released 2015-06-17)
 
 - Adds support for long (Python 2) integers.

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 ===================================
- CERN Service XML v0.1.2 is released
+ CERN Service XML v0.2.0 is released
 ===================================
 
-CERN Service XML v0.1.2 was released on 2015-06-17
+CERN Service XML v0.2.0 was released on TBD
 
 About
 -----
@@ -12,7 +12,9 @@ CERN Service XML is a small library to generate a CERN XSLS Service XML.
 What's new
 ----------
 
-- Adds support for long (Python 2) integers.
+- Adds support for service status parameter in ``ServiceDocument``.
+- Deprecates use of service availability percentage in ``ServiceDocument``.
+  Please use service status parameter instead.
 
 Installation
 ------------
@@ -22,7 +24,7 @@ Installation
 Documentation
 -------------
 
-   http://cernservicexml.readthedocs.org/en/v0.1.2
+   http://cernservicexml.readthedocs.org/en/v0.2.0
 
 Homepage
 --------

--- a/cernservicexml/__init__.py
+++ b/cernservicexml/__init__.py
@@ -11,8 +11,8 @@
 
 from __future__ import absolute_import, print_function, unicode_literals
 
-from .document import ServiceDocument
+from .document import ServiceDocument, Status
 from .publisher import XSLSPublisher
 from .version import __version__
 
-__all__ = ('ServiceDocument', 'XSLSPublisher', '__version__')
+__all__ = ('ServiceDocument', 'Status', 'XSLSPublisher', '__version__')

--- a/cernservicexml/document.py
+++ b/cernservicexml/document.py
@@ -11,19 +11,34 @@
 
 Usage:
 
->>> from cernservicexml import ServiceDocument
->>> doc = ServiceDocument('zenodo')
+>>> from cernservicexml import ServiceDocument, Status
+>>> doc = ServiceDocument('zenodo', status=Status.available)
 >>> doc.add_numericvalue('users', 1000, desc="Number of users")
 >>> xml = doc.to_xml()
 """
 
 from __future__ import absolute_import, print_function, unicode_literals
 
+import warnings
 import xml.etree.ElementTree as ET
 from datetime import datetime
 from decimal import Decimal
 
-from ._compat import string_types, text_type, binary_type, long_type
+from ._compat import binary_type, long_type, string_types, text_type
+
+
+class Status(object):
+
+    """Representation of availability status."""
+
+    available = 'available'
+    """Service is available for all users."""
+
+    degraded = 'degraded'
+    """Part of the service is not be working or some users are affected."""
+
+    unavailable = 'unavailable'
+    """Service is unavailable for all users."""
 
 
 class ServiceDocument(object):
@@ -31,34 +46,91 @@ class ServiceDocument(object):
     """XSLS Service Document class.
 
     :param service_id: A unique service id.
-    :param availability: An integer 0-100 indicating availability of service.
-        Default: 100.
-    :param timestamp: Timestamp when the availability was calculated. Must be
-        a datetime object. Default: now.
+    :param availability: An integer 0-100 indicating availability of
+        service (*deprecated*, use ``status`` instead). Default: 100.
+    :param status: Status of the service. Allowed values: ``available``,
+        ``degraded`` or ``unavailable``. Default: ``available``.
+    :param timestamp: Timestamp when the availability was calculated. Must
+        be a datetime object. Default: now.
     :param availabilitydesc: Information about the availability.
     :param contact: Service contacts a string.
     :param webpage: Service website (any URI)
-    :param availabilityinfo: Information about the service. Can contain HTML.
+    :param availabilityinfo: Information about the service. Can contain
+        HTML.
+
+    .. versionchanged:: 0.2
+       Added ``status`` parameter. Deprecated ``availability``
+       parameter.
     """
 
-    def __init__(self, service_id, availability=100, timestamp=None,
+    STATUSES = [Status.available, Status.degraded, Status.unavailable]
+    """Allowed status values."""
+
+    def __init__(self, service_id, status=None, timestamp=None,
                  availabilitydesc=None, contact=None, webpage=None,
-                 availabilityinfo=None):
+                 availabilityinfo=None,
+                 availability=None):
         """Initialize a service document."""
         if timestamp is not None:
             assert isinstance(timestamp, datetime)
         assert isinstance(service_id, string_types)
-        assert isinstance(availability, int)
-        assert availability >= 0 and availability <= 100
+
+        if status is not None:
+            assert status in self.STATUSES
+            if availability is not None:
+                raise AssertionError(
+                    "Status and availability cannot be specified at the same "
+                    "time. Please use only status."
+                )
+        elif availability is not None:
+            warnings.warn(
+                "Keyword argument 'availability' is deprecated and will be "
+                "removed in v0.3. Please use keyword argument 'status' "
+                "instead.", DeprecationWarning)
+            assert isinstance(availability, int)
+            assert availability >= 0 and availability <= 100
+            self._availablity = availability
+            if availability >= 0 and availability < 40:
+                status = Status.unavailable
+            elif availability >= 40 and availability < 70:
+                status = Status.degraded
+            elif availability >= 70 and availability <= 100:
+                status = Status.available
+        else:
+            status = Status.available
 
         self.service_id = service_id
-        self.availability = availability
+        self.status = status
         self.timestamp = timestamp or datetime.now()
         self.availabilitydesc = availabilitydesc
         self.contact = contact
         self.webpage = webpage
         self.availabilityinfo = availabilityinfo
         self.data = []
+
+    @property
+    def availability(self):
+        """Get status as legacy availability percentage.
+
+        .. deprecated:: 0.2
+           Use of availability as percentage is deprecated. Please use
+           ``status`` instead. Attribute will be removed in v0.3.
+        """
+        warnings.warn(
+            "Use of availability attribute is deprecated. Please use status "
+            "attribute instead.", DeprecationWarning)
+
+        # If availability was set via constructor return that value.
+        if hasattr(self, '_availablity'):
+            return self._availablity
+
+        # Otherwise, compute availability from status.
+        if self.status == Status.available:
+            return 100
+        elif self.status == Status.degraded:
+            return 50
+        else:
+            return 0
 
     def add_numericvalue(self, name, value, desc=None):
         """Add a numeric value metric.
@@ -80,7 +152,7 @@ class ServiceDocument(object):
         root = ET.Element('serviceupdate',
                           xmlns="http://sls.cern.ch/SLS/XML/update")
         ET.SubElement(root, 'id').text = self.service_id
-        ET.SubElement(root, 'availability').text = text_type(self.availability)
+        ET.SubElement(root, 'status').text = text_type(self.status)
         ET.SubElement(root, 'timestamp').text = self.timestamp.isoformat()
 
         for e in ['availabilitydesc', 'contact', 'webpage',

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,4 +9,5 @@
 
 pep257 cernservicexml && \
 sphinx-build -qnNW docs docs/_build/html && \
-python setup.py test
+python setup.py test && \
+sphinx-build -qnNW -b doctest docs docs/_build/doctest

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -42,5 +42,5 @@ def test_xslspublisher_send():
     assert 'file' in data
     assert data['file'][0].decode('utf-8') == \
         '<serviceupdate xmlns="http://sls.cern.ch/SLS/XML/update">' \
-        '<id>myid</id><availability>100</availability>' \
+        '<id>myid</id><status>available</status>' \
         '<timestamp>2015-01-01T00:00:00</timestamp></serviceupdate>'

--- a/tests/xsls_schema.xsd
+++ b/tests/xsls_schema.xsd
@@ -7,71 +7,73 @@
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 -->
-  <xs:schema
-   xmlns:xs="http://www.w3.org/2001/XMLSchema"
-   xmlns:tns="http://sls.cern.ch/SLS/XML/update"
-   targetNamespace="http://sls.cern.ch/SLS/XML/update"
-   elementFormDefault="qualified"
-   attributeFormDefault="unqualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://sls.cern.ch/SLS/XML/update" targetNamespace="http://sls.cern.ch/SLS/XML/update" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <!--  Types  -->
+    <xs:simpleType name="singleId">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="([a-zA-Z0-9\.\-_])+"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="stringNonEmpty">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="percentage">
+        <xs:restriction base="xs:decimal">
+            <xs:minInclusive value="0"/>
+            <xs:maxInclusive value="100"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <xs:simpleType name="statusChoices">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="unavailable"/>
+            <xs:enumeration value="degraded"/>
+            <xs:enumeration value="available"/>
+        </xs:restriction>
+    </xs:simpleType>
 
-  <!-- Types -->
-  <xs:simpleType name="singleId">
-    <xs:restriction base="xs:string">
-      <xs:pattern value="([a-zA-Z0-9\.\-_])+" />
-    </xs:restriction>
-  </xs:simpleType>
+    <xs:element name="availability_or_status" abstract="true" />
+    <xs:element name="status" substitutionGroup="tns:availability_or_status" type="tns:statusChoices"/>
+    <xs:element name="availability" substitutionGroup="tns:availability_or_status" type="tns:percentage"/>
 
-  <xs:simpleType name="stringNonEmpty">
-    <xs:restriction base="xs:string">
-      <xs:minLength value="1" />
-    </xs:restriction>
-  </xs:simpleType>
-  <xs:simpleType name="percentage">
-    <xs:restriction base="xs:decimal">
-      <xs:minInclusive value="0" />
-      <xs:maxInclusive value="100" />
-    </xs:restriction>
-  </xs:simpleType>
+    <!--  Schema  -->
+    <xs:element name="serviceupdate">
+        <xs:complexType>
+            <xs:all>
+                <!--  Mandatory fields  -->
+                <xs:element name="id" type="tns:singleId"/>
+                <xs:element name="timestamp" type="xs:dateTime"/>
+                <xs:element ref="tns:availability_or_status" minOccurs="1"/>
 
-  <!-- Schema -->
-  <xs:element name="serviceupdate">
-    <xs:complexType>
-      <xs:all>
-        <!-- Mandatory fields -->
-        <xs:element name="id" type="tns:singleId" />
-        <xs:element name="timestamp" type="xs:dateTime" />
-        <xs:element name="availability" type="tns:percentage" />
-
-        <!-- Optional fields -->
-        <xs:element name="availabilityinfo" minOccurs="0" maxOccurs="1">
-          <xs:complexType mixed="true">
-            <xs:sequence>
-              <xs:any processContents="skip" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
-          </xs:complexType>
-        </xs:element>
-
-        <xs:element name="availabilitydesc" type="tns:stringNonEmpty" minOccurs="0" maxOccurs="1" />
-        <xs:element name="contact" type="tns:stringNonEmpty" minOccurs="0" maxOccurs="1"/>
-        <xs:element name="webpage" type="xs:anyURI" minOccurs="0" maxOccurs="1"/>
-
-        <xs:element name="data" minOccurs="0" maxOccurs="1">
-          <xs:complexType>
-            <xs:sequence>
-              <xs:element name="numericvalue" minOccurs="1" maxOccurs="unbounded">
-                <xs:complexType>
-                  <xs:simpleContent>
-                    <xs:extension base="xs:decimal">
-                      <xs:attribute name="name" type="tns:stringNonEmpty" use="required" />
-                      <xs:attribute name="desc" type="tns:stringNonEmpty" use="optional" />
-                    </xs:extension>
-                  </xs:simpleContent>
-                </xs:complexType>
-              </xs:element>
-            </xs:sequence>
-          </xs:complexType>
-        </xs:element>
-      </xs:all>
-    </xs:complexType>
-  </xs:element>
+                <!--  Optional fields  -->
+                <xs:element name="availabilityinfo" minOccurs="0" maxOccurs="1">
+                    <xs:complexType mixed="true">
+                        <xs:sequence>
+                            <xs:any processContents="skip" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="availabilitydesc" type="tns:stringNonEmpty" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="contact" type="tns:stringNonEmpty" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="webpage" type="xs:anyURI" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="data" minOccurs="0" maxOccurs="1">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="numericvalue" minOccurs="1" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:simpleContent>
+                                        <xs:extension base="xs:decimal">
+                                            <xs:attribute name="name" type="tns:stringNonEmpty" use="required"/>
+                                            <xs:attribute name="desc" type="tns:stringNonEmpty" use="optional"/>
+                                        </xs:extension>
+                                    </xs:simpleContent>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
 </xs:schema>


### PR DESCRIPTION
* Adds support for service status parameter in ``ServiceDocument``.
  (closes #10)

* Deprecates use of service availability percentage in
  ``ServiceDocument``. Please use service status parameter instead.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>