### PR TITLE
global: software and package name standardisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-CERN Service XML is free software; you can redistribute it and/or modify it
+CERNServiceXML is free software; you can redistribute it and/or modify it
 under the terms of the Revised BSD License quoted below.
 
 Copyright (C) 2015 CERN.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-==================
- CERN Service XML
-==================
+================
+ CERNServiceXML
+================
 
 .. image:: https://travis-ci.org/inveniosoftware/cernservicexml.svg?branch=master
     :target: https://travis-ci.org/inveniosoftware/cernservicexml
@@ -13,17 +13,20 @@
 
 About
 =====
-CERN Service XML is a small library to generate a CERN XSLS Service XML and
-sending it to a remove service.
+
+CERNServiceXML is a small library to generate a CERN XSLS Service XML
+and sending it to a remove service.
 
 Installation
 ============
-CERN Service XML is on PyPI so all you need is: ::
+
+CERNServiceXML is on PyPI so all you need is: ::
 
     pip install cernservicexml
 
 Documentation
 =============
+
 Documentation is readable at http://cernservicexml.readthedocs.org or can be
 build using Sphinx: ::
 
@@ -32,6 +35,7 @@ build using Sphinx: ::
 
 Testing
 =======
+
 Running the test suite is as simple as: ::
 
     python setup.py test

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,13 +1,13 @@
 ===================================
- CERN Service XML v0.2.0 is released
+ CERNServiceXML v0.2.0 is released
 ===================================
 
-CERN Service XML v0.2.0 was released on 2015-07-16
+CERNServiceXML v0.2.0 was released on July 16, 2015.
 
 About
 -----
 
-CERN Service XML is a small library to generate a CERN XSLS Service XML.
+CERNServiceXML is a small library to generate CERN XSLS Service XML.
 
 What's new
 ----------
@@ -35,7 +35,7 @@ Homepage
 
    https://github.com/inveniosoftware/cernservicexml
 
-Good luck and thanks for choosing CERN Service XML.
+Happy hacking and thanks for flying CERNServiceXML.
 
 | Invenio Development Team
 |   Email: info@invenio-software.org

--- a/cernservicexml/__init__.py
+++ b/cernservicexml/__init__.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 
-"""CERN Service XML is a small library to generate a CERN XSLS Service XML."""
+"""CERNServiceXML is a small library to generate a CERN XSLS Service XML."""
 
 from __future__ import absolute_import, print_function, unicode_literals
 

--- a/cernservicexml/_compat.py
+++ b/cernservicexml/_compat.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 

--- a/cernservicexml/document.py
+++ b/cernservicexml/document.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 

--- a/cernservicexml/publisher.py
+++ b/cernservicexml/publisher.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 

--- a/cernservicexml/version.py
+++ b/cernservicexml/version.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 
@@ -48,7 +48,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'CERN Service XML'
+project = u'CERNServiceXML'
 copyright = u'2015, CERN'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -209,7 +209,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'cernservicexml.tex', u'CERN Service XML Documentation',
+  ('index', 'cernservicexml.tex', u'CERNServiceXML Documentation',
    u'CERN', 'manual'),
 ]
 
@@ -239,7 +239,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'cernservicexml', u'CERN Service XML Documentation',
+    ('index', 'cernservicexml', u'CERNServiceXML Documentation',
      [u'CERN'], 1)
 ]
 
@@ -253,7 +253,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'cernservicexml', u'CERN Service XML Documentation',
+  ('index', 'cernservicexml', u'CERNServiceXML Documentation',
    u'CERN', 'cernservicexml', 'One line description of project.',
    'Miscellaneous'),
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
-==================
- CERN Service XML
-==================
+================
+ CERNServiceXML
+================
 .. currentmodule:: cernservicexml
 
 .. raw:: html
@@ -22,7 +22,7 @@
 Installation
 ============
 
-The CERN Service XML package is on PyPI so all you need is:
+The CERNServiceXML package is on PyPI so all you need is:
 
 .. code-block:: console
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 #
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 #
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 

--- a/tests/xsls_schema.xsd
+++ b/tests/xsls_schema.xsd
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 -->

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
-# This file is part of CERN Service XML
+# This file is part of CERNServiceXML
 # Copyright (C) 2015 CERN.
 #
-# CERN Service XML is free software; you can redistribute it and/or modify
+# CERNServiceXML is free software; you can redistribute it and/or modify
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 


### PR DESCRIPTION
* Standardises software name (CERNServiceXML) and package
  name (cernservicexml) following usual inveniosoftware practices.

* Amends greeting phrase from "good luck" to "happy hacking" for similar
  reasons.

* Fixes reST headline formatting in `RELEASE-NOTES.rst`.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>