### PR TITLE
travis: universal wheel build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,9 @@
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 
+[wheel]
+universal=1
+
 [build_sphinx]
 source-dir = docs/
 build-dir = docs/_build


### PR DESCRIPTION
* Changes PyPI automatic deployment to build universal wheel instead
  of Python 2 wheel only.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>