### PR TITLE
docs: MAINTAINERS file and LGTM configuration

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,0 +1,3 @@
+approvals = 1
+pattern = "(?i)LGTM"
+self_approval_off = true

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Lars Holm Nielsen <lars.holm.nielsen@cern.ch> (@lnielsen)


### PR DESCRIPTION
* Adds the MAINTAINERS file and the initial LGTM configuration.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>