### PR TITLE
Adding check-manifest

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Contact us at `info@inveniosoftware.org <mailto:info@inveniosoftware.org>`_
 
 * Lars Holm Nielsen <lars.holm.nielsen@cern.ch>
 * Tibor Simko <tibor.simko@cern.ch>
+* Andy Craze <accraze@gmail.com>

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,7 +7,7 @@
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 
-pydocstyle cernservicexml && \
+check-manifest && pydocstyle cernservicexml && \
 sphinx-build -qnNW docs docs/_build/html && \
 python setup.py test && \
 sphinx-build -qnNW -b doctest docs docs/_build/doctest

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ tests_require = [
     'mock>=1.0',
     'lxml>=3.4',
     'pydocstyle>=1.0.0',
+    'check-manifest'
 ]
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -17,9 +17,11 @@ commands = {envpython} setup.py test
 # See https://wiki.python.org/moin/TestPyPI
 [testenv:release]
 deps =
+    check-manifest
     twine >= 1.4.0
     wheel
 commands =
+    check-manifest {toxinidir}
     /bin/rm -Rf {toxinidir}/dist
     {envpython} setup.py clean --all
     {envpython} setup.py sdist bdist_wheel


### PR DESCRIPTION
This PR adds `check-manifest` to your tox.ini file.

check-manifest will be run at the start of `testenv:release`

Fixes #22 