### PR TITLE
lgtm: allow self-approval for single maintainer

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,3 +1,3 @@
 approvals = 1
 pattern = "(?i)LGTM"
-self_approval_off = true
+self_approval_off = false


### PR DESCRIPTION
This repository has only one maintainer, and the self approvals were off. This would make it impossible for the maintainer to push any code...

This PR proposes one solution: to allow self-approval.  Advantage: consistency, since an explicit LGTM action by the maintainer is always required. Disadvantage: an explicit self-approval is silly.
However, it may also be considered a good reminder to the maintainer to move up and find a backup.

An alternative solution: use `approvals = 0`.  Advantage: silly self-approvals wouldn't be necessary. Disadvantage: more fragile setup in case this gets forgotten, less clarity for contributors why sometimes  maintainers uses and sometimes doesn't use LGTM.  (Since approvals wouldn't be required for any contributor branches.)

Not easy to pick between the two, but I guess the former has more advantages than the latter.  (Plus the former is the LGTM default settings, I believe.)

WDYT? @jirikuncar @lnielsen 