### PR TITLE
global: remove python 2.6 and 3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ sudo: false
 language: python
 
 python:
-  - "2.6"
   - "2.7"
-  - "3.3"
   - "3.4"
 
 env:

--- a/setup.py
+++ b/setup.py
@@ -56,10 +56,8 @@ setup(
     },
     classifiers=[
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
* Remove Python 2.6 support because pydocstyle is not compatible.

* Remove Python 3.3 support because Sphinx needs at least Python
  2.7/3.4.

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>